### PR TITLE
Set ownership of nginx.conf.web.http.default back to zimbra user

### DIFF
--- a/certbot_zimbra.sh
+++ b/certbot_zimbra.sh
@@ -197,7 +197,7 @@ function deploy_certificate() {
 	fi
 	
 	# Set ownership of nginx config template
-        chown zimbra.zimbra /opt/zimbra/conf/nginx/includes/nginx.conf.web.http.default
+        chown zimbra:zimbra /opt/zimbra/conf/nginx/includes/nginx.conf.web.http.default
 	
 	# Finally apply cert!
 	su - zimbra -c 'zmcontrol restart'

--- a/certbot_zimbra.sh
+++ b/certbot_zimbra.sh
@@ -195,7 +195,10 @@ function deploy_certificate() {
 	else
 		/opt/zimbra/bin/zmcertmgr deploycrt comm /opt/zimbra/ssl/letsencrypt/cert.pem /opt/zimbra/ssl/letsencrypt/zimbra_chain.pem
 	fi
-
+	
+	# Set ownership of nginx config template
+        chown zimbra.zimbra /opt/zimbra/conf/nginx/includes/nginx.conf.web.http.default
+	
 	# Finally apply cert!
 	su - zimbra -c 'zmcontrol restart'
 	# FIXME And hope that everything started fine! :)


### PR DESCRIPTION
Set ownership of /opt/zimbra/conf/nginx/includes/nginx.conf.web.http.default back to zimbra user (needed for zimbra 8.6.x)