### PR TITLE
fix YetOpen#79: support RHEL/CentOS pki-base, add dependency check

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The script doesn't handle multiple domains configured with SNI (see #8). You can
 ## Requirements
 
 - bash, su, patch, which, lsof or ss, openssl, grep, sed (GNU)
+- ca-certificates (Debian/Ubuntu) or pki-base (RHEL/CentOS)
 - Zimbra: zmhostname, zmcontrol, zmproxyctrl, zmprov, zmcertmgr
 - zimbra-proxy installed and working
 - either certbot, certbot-auto or letsencrypt binary in PATH. These three may be used interchangeably in the rest of the document, depending on what is installed on your system.
@@ -55,10 +56,11 @@ So open `/etc/cron.d/certbot` with your favourite editor and **comment the last 
 Download the latest release and install it (copy the latest URL from the Releases tab):
 
 ```
-wget https://github.com/YetOpen/certbot-zimbra/archive/0.4.0-beta.tar.gz
-tar xzf 0.4.0-beta.tar.gz certbot_zimbra.sh
+wget https://github.com/YetOpen/certbot-zimbra/archive/0.7.3-alpha.tar.gz
+tar xzf 0.7.3-alpha.tar.gz certbot_zimbra.sh
+chmod +x certbot_zimbra.sh
+chown root: certbot_zimbra.sh
 mv certbot_zimbra.sh /usr/local/bin/
-chmod +x /usr/local/bin/certbot_zimbra.sh
 ```
 
 # Usage


### PR DESCRIPTION
- dependency check for ca-certificates or pki-base on start
  (via present .crt files)
- extract CA from tls-ca-bundle.pem

README.md: Add ca-certs|pki-base dependency, update filename in install

This is based on master so I'd skip the 0.7 branch, IMO it's not needed any more and can be deleted.
For the updated readme a new release 0.7.3-alpha is needed