### PR TITLE
Fix erasing issue EXTRA_DOMAINS. It is array, it should be unset instead of overwriting the first value

### DIFF
--- a/certbot_zimbra.sh
+++ b/certbot_zimbra.sh
@@ -335,7 +335,7 @@ get_domain () {
 		echo "Got ${#EXTRA_DOMAINS[@]} domains to use as certificate SANs: ${EXTRA_DOMAINS[@]}"
 		if "$PROMPT_CONFIRM"; then
 			prompt "Include these in the certificate?"
-			(( $? == 1 )) && EXTRA_DOMAINS=""
+			(( $? == 1 )) && unset EXTRA_DOMAINS
 		fi
 	fi
 


### PR DESCRIPTION
Solve issue when a more than 1 EXTRA_DOMAINS but user want not to issue certificates for Extra domains