### PR TITLE
Added preferred-chain flag to Certbot for use with LE old chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.7.12
+
+* Add --preferred-chain to the Certbot command line according to Let's Encrypt
+  [recent changes][1] (#129)
+
+[1]: https://community.letsencrypt.org/t/openssl-client-compatibility-changes-for-let-s-encrypt-certificates/143816
+
+
 ## v0.7.11
 
 * Fix extracting CA from tls-ca-bundle.pem when spaces are removed from CN (#106)

--- a/certbot_zimbra.sh
+++ b/certbot_zimbra.sh
@@ -5,7 +5,7 @@
 # GPLv3 license
 
 PROGNAME="certbot-zimbra"
-VERSION="0.7.11"
+VERSION="0.7.12"
 GITHUB_URL="https://github.com/YetOpen/certbot-zimbra"
 # paths
 ZMPATH="/opt/zimbra"
@@ -445,7 +445,7 @@ request_cert() {
 	"$QUIET" && exec > /dev/null
 	"$QUIET" && exec 2>/dev/null
 	# Request our cert
-	"$LE_BIN" certonly $LE_PARAMS
+	"$LE_BIN" certonly $LE_PARAMS --preferred-chain 'ISRG Root X1'
 	e=$?
 	"$QUIET" && exec > /dev/stdout
 	"$QUIET" && exec 2> /dev/stderr


### PR DESCRIPTION
As seen on issue [https://github.com/YetOpen/certbot-zimbra/issues/129](https://github.com/YetOpen/certbot-zimbra/issues/129)