### PR TITLE
find_additional_public_hostnames() enhancement for virtual hosts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.7.13 (unreleased)
+
+* Change the way certbot-zimbra establishes the list of SAN's - (#161)
+    - In addition to zimbraPublicServiceHostname also look at entries added
+      to zimbraVirtualHostname to find all SAN's for the certificate.
+
 ## v0.7.12
 
 * Use topmost certificate in chain to find CA cert. Fixes #129

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## v0.7.13 (unreleased)
 
 * Change the way certbot-zimbra establishes the list of SAN's (#161)
-    - In addition to zimbraPublicServiceHostname also look at entries added
-      to zimbraVirtualHostname to find all SAN's for the certificate.
+    - In addition to zimbraPublicServiceHostname it also looks at entries
+      added to zimbraVirtualHostname to find all SAN's for the certificate.
 
 ## v0.7.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.7.13 (unreleased)
 
-* Change the way certbot-zimbra establishes the list of SAN's - (#161)
+* Change the way certbot-zimbra establishes the list of SAN's (#161)
     - In addition to zimbraPublicServiceHostname also look at entries added
       to zimbraVirtualHostname to find all SAN's for the certificate.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ USAGE: certbot_zimbra.sh < -d | -n | -p > [-aNuzjxcq] [-H my.host.name] [-e extr
 ```
 
 
-If no `-e` is given, the script will figure out the additional domain(s) to add to the certificate as SANs via `zmprov gd $domain zimbraPublicServiceHostname`.
+If no `-e` is given, the script will figure out the additional domain(s) to add to the certificate as SANs via `zmprov gd $domain zimbraPublicServiceHostname` and `zmprov gd $domain zimbraVirtualHostname`.
 This can be skipped with `-u/--no-public-hostname-detection`, in which case only the CN from `zmhostname` or `-H/--hostname` will be used.
 
 Only one certificate will be issued including all the found hostnames. The primary host will always be `zmhostname`.
@@ -144,7 +144,7 @@ Certbot will also ask you some information about the certificate interactively, 
 
 The domain of the certificate is obtained automatically using `zmhostname`. If you want to request a specific hostname use the `-H/--hostname` option. This domain will be the DN of the certificate.
 
-The certificate can be requested with additional hostnames/SANs. By default the script fetches the `zimbraPublicServiceHostname` attribute from all domains and if present, adds it to the certificate SANs to be requested. If you want to disable this behavior use the `-u/--no-public-hostname-detection` option.
+The certificate can be requested with additional hostnames/SANs. By default the script fetches the `zimbraPublicServiceHostname` and all `zimbraVirtualHostname` attributes from all domains and if present, adds those to the certificate SANs to be requested. If you want to disable this behavior use the `-u/--no-public-hostname-detection` option.
 
 **Note:** Let's Encrypt has a limit of a maximum of 100 domains per certificate at the time of this writing: [Rate Limits](https://letsencrypt.org/docs/rate-limits/)
 

--- a/certbot_zimbra.sh
+++ b/certbot_zimbra.sh
@@ -329,11 +329,11 @@ find_additional_public_hostnames() {
 		
 		# add finding to our list
 		if [ -n "${additional_domains}" ]; then
-			! "$quiet" && echo "Found additional domains: ${additional_domains}"
+			! "$quiet" && echo " - domain ${domain_entry}: ${additional_domains}"
 			extra_domains+=(${additional_domains})
 		fi
 	done
-	! "$quiet" && echo "Found ${#extra_domains[@]} zimbraPublicServiceHostnames through auto-detection"
+	! "$quiet" && echo "Found ${#extra_domains[@]} through auto-detection (zimbraPublicServiceHostname, zimbraVirtualHostname)"
 
 	unset all_domains domain_entry additional_domains
 	return 0

--- a/certbot_zimbra.sh
+++ b/certbot_zimbra.sh
@@ -5,7 +5,7 @@
 # GPLv3 license
 
 readonly progname="certbot-zimbra"
-readonly version="0.7.12"
+readonly version="0.7.13 (unreleased)"
 readonly github_url="https://github.com/YetOpen/certbot-zimbra"
 # paths
 readonly zmpath="/opt/zimbra"

--- a/certbot_zimbra.sh
+++ b/certbot_zimbra.sh
@@ -335,6 +335,7 @@ find_additional_public_hostnames() {
 	done
 	! "$quiet" && echo "Found ${#extra_domains[@]} zimbraPublicServiceHostnames through auto-detection"
 
+	unset all_domains domain_entry additional_domains
 	return 0
 }
 

--- a/certbot_zimbra.sh
+++ b/certbot_zimbra.sh
@@ -313,10 +313,26 @@ find_additional_public_hostnames() {
 		return
 	fi
 
-	! "$quiet" && echo -n "Detecting additional public service hostnames... "
+	! "$quiet" && echo "Detecting additional public service hostnames:"
 
-	extra_domains=($(su - zimbra -c "zmprov $zmprov_opts gad" | gawk '{printf "gd %s zimbraPublicServiceHostname\n", $0}' \
-			| su - zimbra -c "zmprov $zmprov_opts -" | sed "/prov>/d;/# name/d;/$domain/d;/^$/d;s/zimbraPublicServiceHostname: \(.*\)/\1/"))
+	# process all Zimbra domains
+	all_domains=($(su - zimbra -c "zmprov $zmprov_opts gad" | tr '\n' ' '))
+	for domain_entry in ${all_domains[@]}; do
+		! "$quiet" echo "Processing: ${domain_entry}"
+		additional_domains=$((su - zimbra -c "zmprov $zmprov_opts gd ${domain_entry} zimbraPublicServiceHostname" \
+			| sed "/prov>/d;/# name/d;/^$/d;s/zimbraPublicServiceHostname: \(.*\)/\1/"; \
+			su - zimbra -c "zmprov $zmprov_opts gd ${domain_entry} zimbraVirtualHostname" \
+			| sed "/prov>/d;/# name/d;/^$/d;s/zimbraVirtualHostname: \(.*\)/\1/") \
+			| sort | uniq | tr '\n' ' ')
+		# if domain is actually a hostname add it to the list
+		[ -z "${additional_domains}" -a "${domain_entry}" != "${domain}" ] && additional_domains="${domain_entry}"
+		
+		# add finding to our list
+		if [ -n "${additional_domains}" ]; then
+			! "$quiet" && echo "Found additional domains: ${additional_domains}"
+			extra_domains+=(${additional_domains})
+		fi
+	done
 	! "$quiet" && echo "Found ${#extra_domains[@]} zimbraPublicServiceHostnames through auto-detection"
 
 	return 0


### PR DESCRIPTION
Change the way certbot-zimbra establishes the list of SAN's (#161).
In addition to zimbraPublicServiceHostname also look at entries added
to zimbraVirtualHostname to find all SAN's for the certificate.